### PR TITLE
Updating wget dependency to match the one in ModuleFile

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,3 +1,3 @@
 forge 'http://forge.puppetlabs.com'
 
-mod 'maestrodev/wget', '>=0.0.1'
+mod 'maestrodev/wget', '>=1.0.0'


### PR DESCRIPTION
Issue with librarian-puppet when duplicate dependencies are present. Below is the error

```shell
[Librarian] lockfile_text: 
FORGE
  remote: https://forgeapi.puppetlabs.com
  specs:
    maestrodev-wget (1.5.7)
    puppetlabs-stdlib (4.5.1)

GIT
  remote: https://github.com/snandam/puppet-ant.git
  ref: f68af3bf6a8c831aea562284c2de0f6eaa224ee3
  sha: f68af3bf6a8c831aea562284c2de0f6eaa224ee3
  specs:
    puppet-ant (1.0.6)
      maestrodev-wget (>= 0.0.1)
      maestrodev-wget (>= 1.0.0)
      puppetlabs-stdlib (>= 3.2.0)
```

https://github.com/rodjek/librarian-puppet/issues/223

Updated the Puppetfile dependency to match the one defined in ModuleFile